### PR TITLE
ci: pin GitHub Actions to SHA-256 commits

### DIFF
--- a/.github/workflows/formula-update.yml
+++ b/.github/workflows/formula-update.yml
@@ -37,14 +37,14 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Update Homebrew Formula for ${{ env.PROJECT }}
         run: |
           sed -i 's/tag: "[^"]*"/tag: "${{  env.RELEASE_TAG }}"/' ./Formula/${{ env.PROJECT }}.rb
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         id: create_pr
         with:
           delete-branch: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Homebrew
         run: |


### PR DESCRIPTION
## Summary
- Pin every `uses:` reference in workflows to a specific commit SHA
- Each pin is annotated with the corresponding version tag in a trailing comment
- Versions stay within the existing major (e.g. `@v4` → latest v4.x.y SHA) to avoid breaking changes

## Why
Mitigates supply-chain attacks where a tag could be retargeted to malicious code. Pinning to a SHA is the [recommended hardening practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Notes for reviewers
- Annotated tags resolve to the underlying commit SHA (not the tag object)
- For `SiaFoundation/workflows@master` and `dtolnay/rust-toolchain@stable|nightly` (which use a branch ref intentionally), the pin uses the current branch tip SHA — future updates will require a follow-up PR
- This PR was generated by tooling; please skim each workflow diff
